### PR TITLE
Fix CTR percentage parsing

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -12,10 +12,10 @@
                           .replace(/>/g,'&gt;');
   const pct = n => `${(+n).toFixed(2)}%`;
   const asPct = raw=>{
-    let n = parseFloat(String(raw||'').replace('%',''));
+    let n = parseFloat(String(raw || '').replace('%', ''));
     if (!isFinite(n)) return 0;
-    if (n < 0.1) n *= 1e4; else if (n <= 1) n *= 100;
-    return n;
+    if (n > 1) return n;    // already expressed as a percentage
+    return n * 100;          // convert fraction to percent
   };
   const delta = (du,bk)=>{
     const d = du - bk; if (!isFinite(d)||d===0) return '0';

--- a/server.js
+++ b/server.js
@@ -37,10 +37,10 @@ const esc = s => (s||'').replace(/&/g,'&amp;')
                         .replace(/>/g,'&gt;');
 const pct = n => `${n.toFixed(2)}%`;
 const asPct = raw=>{
-  let n = parseFloat(String(raw||'').replace('%',''));
+  let n = parseFloat(String(raw || '').replace('%', ''));
   if (!isFinite(n)) return 0;
-  if (n < 0.1) n *= 1e4; else if (n <= 1) n *= 100;
-  return n;
+  if (n > 1) return n;   // already a percentage like 5 or 75
+  return n * 100;         // convert fraction to percent
 };
 const delta = (du,bk)=>{
   const d = du - bk; if (!isFinite(d)||d===0) return '0';


### PR DESCRIPTION
## Summary
- correct CTR percentage scaling when values are below 10%

## Testing
- `npm install`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6877d8b8b17483298ec549291461f718